### PR TITLE
adding support for proxy header being email address

### DIFF
--- a/config_example.php
+++ b/config_example.php
@@ -29,6 +29,10 @@ $config['auth'] = [
          * Email domain for automatically created users.
          */
         'domain' => null,
+        /**
+         * If the subject in the header is an email address.
+         */
+        'subject_is_email' => false,
     ],
     'api' => [
         /**


### PR DESCRIPTION
I'm adding this support back in since our auth service is passing an email address instead of a username.