### PR TITLE
Add platform reqs in composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
   - cp tests/config_test.php config.php
   - cp tests/hook_test.php hook.php
   - ./vendor/bin/phpunit --configuration tests/phpunit.xml --coverage-clover build/logs/clover.xml
-  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then bash ./vendor/bin/test-reporter; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then ./vendor/bin/test-reporter; fi'
 cache:
   directories:
     - vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
   - cp tests/config_test.php config.php
   - cp tests/hook_test.php hook.php
   - ./vendor/bin/phpunit --configuration tests/phpunit.xml --coverage-clover build/logs/clover.xml
-  - ./vendor/bin/test-reporter
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then bash ./vendor/bin/test-reporter; fi'
 cache:
   directories:
     - vendor

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,9 @@
         "symfony/expression-language": "^3.1",
         "elasticsearch/elasticsearch": "~2",
         "kiwiz/esquery": "dev-master",
-        "kiwiz/ecl": "dev-master"
+        "kiwiz/ecl": "dev-master",
+        "ext-pcntl": "^5.5",
+        "php": "^5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f65623b6517a03261f1681ff1dd9bfd1",
+    "content-hash": "e935a4a6058f91733bcb566cd0203f27",
     "packages": [
         {
             "name": "codeclimate/php-test-reporter",
@@ -4732,6 +4732,9 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "ext-pcntl": "^5.5",
+        "php": "^5.5"
+    },
     "platform-dev": []
 }


### PR DESCRIPTION
Just adding the minimum platform reqs in composer to have 411 up and running.

It's nice to have for PAAS services like Heroku for having all the PHP extensions installed.