### PR TITLE
Add platform reqs in composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,9 @@
         "symfony/expression-language": "^3.1",
         "elasticsearch/elasticsearch": "~2",
         "kiwiz/esquery": "dev-master",
-        "kiwiz/ecl": "dev-master"
+        "kiwiz/ecl": "dev-master",
+        "ext-pcntl": "^5.5",
+        "php": "^5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "f65623b6517a03261f1681ff1dd9bfd1",
+    "content-hash": "e935a4a6058f91733bcb566cd0203f27",
     "packages": [
         {
             "name": "codeclimate/php-test-reporter",
@@ -4732,6 +4732,9 @@
     },
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": [],
+    "platform": {
+        "ext-pcntl": "^5.5",
+        "php": "^5.5"
+    },
     "platform-dev": []
 }


### PR DESCRIPTION
Just adding the minimum platform requirements in composer for having 411 up and running.

It's nice to have for PAAS services like Heroku to get all the PHP required extensions installed.