### PR TITLE
Ignore codeclimate report generation for PR's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
   - cp tests/config_test.php config.php
   - cp tests/hook_test.php hook.php
   - ./vendor/bin/phpunit --configuration tests/phpunit.xml --coverage-clover build/logs/clover.xml
-  - ./vendor/bin/test-reporter
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./vendor/bin/test-reporter; fi' 
 cache:
   directories:
     - vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script:
   - cp tests/config_test.php config.php
   - cp tests/hook_test.php hook.php
   - ./vendor/bin/phpunit --configuration tests/phpunit.xml --coverage-clover build/logs/clover.xml
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then bash ./vendor/bin/test-reporter; fi' 
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./vendor/bin/test-reporter; fi' 
 cache:
   directories:
     - vendor


### PR DESCRIPTION
The PR builds always fail in the CodeClimate generation report step because the env variable "CODECLIMATE_REPO_TOKEN" is missing.