### PR TITLE
Using tls client cert and key to connect to 411_alert index

### DIFF
--- a/phplib/ESClient.php
+++ b/phplib/ESClient.php
@@ -60,6 +60,12 @@ class ESClient {
         if(!is_null($escfg['ssl_cert'])) {
             $cb->setSSLVerification($escfg['ssl_cert']);
         }
+        if(!is_null($escfg['ssl_client_key'])) {
+            $cb->setSSLKey($escfg['ssl_client_key']);
+        }
+        if(!is_null($escfg['ssl_client_cert'])) {
+            $cb->setSSLCert($escfg['ssl_client_cert']);
+        }
 
         return $cb->build();
     }


### PR DESCRIPTION
Using certificates to authenticate the ES connections was working only on the source indices, but not on the alerts index (411_alert_). The bug was produced due to the fact that the client certificate and private key  were not being set at the function getClient in the ESClient.php file. 